### PR TITLE
Fix: Detalles de Asistentes

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -15,24 +15,24 @@ CARACTER_CHOICES = {
     'chofer': 'Chofer',
 }
 
-GRUPO_FACTOR_CHOICES = {
-    'a+': 'A (+)',
-    'b+': 'B (+)',
-    'ab+': 'AB (+)',
-    'o+': 'O (+)',
-    'a-': 'A (-)',
-    'b-': 'B (-)',
-    'ab-': 'AB (-)',
-    'o-': 'O (-)'
-}
+GRUPO_FACTOR_CHOICES = [
+    ('a+', 'A (+)'),
+    ('b+', 'B (+)'),
+    ('ab+', 'AB (+)'),
+    ('o+', 'O (+)'),
+    ('a-', 'A (-)'),
+    ('b-', 'B (-)'),
+    ('ab-', 'AB (-)'),
+    ('o-', 'O (-)')
+]
 
-REGIMEN_COMIDA_CHOICES = {
-    'ninguno': 'Sin Restricciones',
-    'vegetariano': 'Vegetariano',
-    'celiaco': 'Celiaco',
-    'vegano': 'Vegano',
-    'otros': 'Otros'
-}
+REGIMEN_COMIDA_CHOICES = [
+    ('ninguno', 'Sin Restricciones'),
+    ('vegetariano', 'Vegetariano'),
+    ('celiaco', 'Celiaco'),
+    ('vegano', 'Vegano'),
+    ('otros', 'Otros')
+]
 
 # Create your models here.
 

--- a/src/core/templates/admin/actividad_inscriptos.html
+++ b/src/core/templates/admin/actividad_inscriptos.html
@@ -58,7 +58,7 @@
                                 
                                     <!-- Ver más información del inscripto -->
                                     <button class="btn btn-info btn-sm" data-bs-toggle="modal" data-bs-target="#detailsModal"
-                                        onclick="setModalDetails('{{ un_asistente.pk }}', '{{ un_asistente.user.first_name }}', '{{ un_asistente.user.last_name }}', '{{ un_asistente.user.email }}', '{{ un_asistente.documento }}', '{{ un_asistente.cuit }}', '{{ un_asistente.fecha_nacimiento }}', '{{ un_asistente.telefono_personal }}', '{{ un_asistente.telefono_emergencia }}', '{{ un_asistente.dependencia }}', '{{ un_asistente.grupo_sanguineo }}', '{{ un_asistente.regimen_comida }}', '{{ un_asistente.regimen_comida_otro }}', '{{ un_asistente.alergia }}', '{{ un_asistente.alergia_otro }}', '{{ un_asistente.medicamento }}', '{{ un_asistente.medicamento_otro }}')">
+                                        onclick="setModalDetails('{{ un_asistente.pk }}', '{{ un_asistente.user.first_name }}', '{{ un_asistente.user.last_name }}', '{{ un_asistente.user.email }}', '{{ un_asistente.documento }}', '{{ un_asistente.cuit }}', '{{ un_asistente.fecha_nacimiento }}', '{{ un_asistente.telefono_personal }}', '{{ un_asistente.telefono_emergencia }}', '{{ un_asistente.dependencia }}', '{{ un_asistente.get_grupo_sangineo_display }}', '{{ un_asistente.get_regimen_comida_display }}', '{{ un_asistente.regimen_comida_otro }}', '{{ un_asistente.alergia }}', '{{ un_asistente.alergia_otro }}', '{{ un_asistente.medicamento }}', '{{ un_asistente.medicamento_otro }}')">
                                         {% bs_icon 'eye' %}
                                     </button>
                                     
@@ -189,6 +189,16 @@
         }
 
         function setModalDetails(pk, nombre, apellido, email, documento, cuit, fechaNacimiento, telefonoPersonal, telefonoEmergencia, dependencia, grupoSanguineo, regimenComida, regimenComidaOtro, alergias, otraAlergia, medicamentos, otroMedicamento) {
+            
+            if(regimenComidaOtro =='')
+                regimenComidaOtro = 'no'
+
+            if(otraAlergia =='')
+                otraAlergia = 'no'
+
+            if(otroMedicamento =='')
+                otroMedicamento = 'no'
+            
             document.getElementById('modalNombre').innerText = nombre;
             document.getElementById('modalApellido').innerText = apellido.toUpperCase();
             document.getElementById('modalEmail').innerText = email;

--- a/src/core/templates/usuarios/coordinador_home.html
+++ b/src/core/templates/usuarios/coordinador_home.html
@@ -74,7 +74,7 @@
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header position-relative">
-                <div class="w-100 text-center"> <!-- Este div centra el título -->
+                <div class="w-100 text-center">
                     <h5 class="modal-title" id="detailsModalLabel">Detalles del Usuario Asistente</h5>
                 </div>
                 <button type="button" class="btn-close position-absolute" style="right: 1rem;" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -108,7 +108,7 @@
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header position-relative">
-                <div class="w-100 text-center"> <!-- Este div centra el título -->
+                <div class="w-100 text-center">
                     <h5 class="modal-title" id="actividadesModalLabel">Actividades del Usuario Asistente</h5>
                 </div>
                 <button type="button" class="btn-close position-absolute" style="right: 1rem;" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/src/core/templates/usuarios/coordinador_home.html
+++ b/src/core/templates/usuarios/coordinador_home.html
@@ -170,7 +170,7 @@
             });
         });
 
-  function setModalDetails(nombre, apellido, email, documento, cuit, fecha_nacimiento, telefono_personal, telefono_emergencia, dependencia, grupo_sangineo, regimen_comida, regimen_comida_otro, alergia, alergia_otro, medicamento, medicamento_otro) {
+  function setModalDetails(nombre, apellido, email, documento, cuit, fecha_nacimiento, telefono_personal, telefono_emergencia, dependencia, grupo_sanguineo, regimen_comida, regimen_comida_otro, alergia, alergia_otro, medicamento, medicamento_otro) {
       
       if(regimen_comida_otro =='')
         regimen_comida_otro = 'no'
@@ -190,7 +190,7 @@
       document.getElementById('modalTelefonoPersonal').textContent = telefono_personal;
       document.getElementById('modalTelefonoEmergencia').textContent = telefono_emergencia;
       document.getElementById('modalDependencia').textContent = dependencia;
-      document.getElementById('modalGrupoSanguineo').textContent = grupo_sangineo;
+      document.getElementById('modalGrupoSanguineo').textContent = grupo_sanguineo;
       document.getElementById('modalRegimenComida').textContent = regimen_comida;
       document.getElementById('modalRegimenComidaOtro').textContent = regimen_comida_otro;
       document.getElementById('modalAlergias').textContent = alergia;

--- a/src/core/templates/usuarios/coordinador_home.html
+++ b/src/core/templates/usuarios/coordinador_home.html
@@ -47,7 +47,7 @@
                             <div class="btn-group" role="group">
                                 <!-- Ver más información del inscripto -->
                                 <button class="btn btn-info btn-sm" data-bs-toggle="modal" data-bs-target="#detailsModal"
-                                    onclick="setModalDetails('{{ un_inscripto.user.first_name }}', '{{ un_inscripto.user.last_name }}', '{{ un_inscripto.user.email }}', '{{ un_inscripto.documento }}', '{{ un_inscripto.cuit }}', '{{ un_inscripto.fecha_nacimiento }}', '{{ un_inscripto.telefono_personal }}', '{{ un_inscripto.telefono_emergencia }}', '{{ un_inscripto.dependencia }}', '{{ un_inscripto.grupo_sanguineo }}', '{{ un_inscripto.regimen_comida }}', '{{ un_inscripto.regimen_comida_otro }}', '{{ un_inscripto.alergia }}', '{{ un_inscripto.alergia_otro }}', '{{ un_inscripto.medicamento }}', '{{ un_inscripto.medicamento_otro }}')">
+                                    onclick="setModalDetails('{{ un_inscripto.user.first_name }}', '{{ un_inscripto.user.last_name }}', '{{ un_inscripto.user.email }}', '{{ un_inscripto.documento }}', '{{ un_inscripto.cuit }}', '{{ un_inscripto.fecha_nacimiento }}', '{{ un_inscripto.telefono_personal }}', '{{ un_inscripto.telefono_emergencia }}', '{{ un_inscripto.dependencia }}', '{{ un_inscripto.get_grupo_sangineo_display }}', '{{ un_inscripto.get_regimen_comida_display }}', '{{ un_inscripto.regimen_comida_otro }}', '{{ un_inscripto.alergia }}', '{{ un_inscripto.alergia_otro }}', '{{ un_inscripto.medicamento }}', '{{ un_inscripto.medicamento_otro }}')">
                                     {% bs_icon 'eye' %}
                                 </button>
                                 <!-- Ver actividades en las que está inscripto -->
@@ -170,7 +170,17 @@
             });
         });
 
-  function setModalDetails(nombre, apellido, email, documento, cuit, fecha_nacimiento, telefono_personal, telefono_emergencia, dependencia, grupo_sanguineo, regimen_comida, regimen_comida_otro, alergia, alergia_otro, medicamento, medicamento_otro) {
+  function setModalDetails(nombre, apellido, email, documento, cuit, fecha_nacimiento, telefono_personal, telefono_emergencia, dependencia, grupo_sangineo, regimen_comida, regimen_comida_otro, alergia, alergia_otro, medicamento, medicamento_otro) {
+      
+      if(regimen_comida_otro =='')
+        regimen_comida_otro = 'no'
+
+      if(alergia_otro =='')
+        alergia_otro = 'no'
+
+      if(medicamento_otro =='')
+        medicamento_otro = 'no'
+      
       document.getElementById('modalNombre').textContent = nombre;
       document.getElementById('modalApellido').textContent = apellido;
       document.getElementById('modalEmail').textContent = email;
@@ -180,7 +190,7 @@
       document.getElementById('modalTelefonoPersonal').textContent = telefono_personal;
       document.getElementById('modalTelefonoEmergencia').textContent = telefono_emergencia;
       document.getElementById('modalDependencia').textContent = dependencia;
-      document.getElementById('modalGrupoSanguineo').textContent = grupo_sanguineo;
+      document.getElementById('modalGrupoSanguineo').textContent = grupo_sangineo;
       document.getElementById('modalRegimenComida').textContent = regimen_comida;
       document.getElementById('modalRegimenComidaOtro').textContent = regimen_comida_otro;
       document.getElementById('modalAlergias').textContent = alergia;


### PR DESCRIPTION
Este PR corrige la visualización de detalles del asistente, para el template del Coordinador y del Admin.

Correcciones:

- Se reemplazaron las listas de grupo sanguíneo y régimen de comida, a una lista de tuplas para cumplir con el formato que Django espera para los campos choices. Esto permite que Django maneje automáticamente la conversión entre las claves almacenadas y los valores legibles en los templates, simplificando el acceso a los valores de grupo_sanguineo. De esta manera ahora se muestran los valores(que son los que mejor escritos están) en lugar de los índices.

- Se agregaron mensajes para cuando los campos del tipo 'Otro' estén vacíos.



